### PR TITLE
Sets max-width of main text sections to 768px, center aligns h1 and h…

### DIFF
--- a/src/styles/screen.scss
+++ b/src/styles/screen.scss
@@ -27,10 +27,27 @@ body {
   section,
   p {
     font-family: $font-body;
-    font-size: 1.2em;
+    font-size: 1em;
     font-weight: 300;
-    max-width: 500px;
+    max-width: 768px;
     line-height: 1.7em;
+  }
+
+  @media (max-width: 640px) {
+    h1,
+    h2 {
+      text-align: center;
+    }
+
+    h2 {
+      font-size: 2.25em;
+    }
+  }
+
+  @media (max-width: 440px) {
+    p {
+      font-size: 1.25em;
+    }
   }
 }
 
@@ -104,9 +121,9 @@ html {
     text-align: left;
 
 
-    p {
-      font-size: 1em;
-    }
+    // p {
+    //   font-size: 1em;
+    // }
   }
 }
 


### PR DESCRIPTION
I added a couple styles to make the mobile situation a bit better.

- Increased the main text area to a max-width of 768px. It was much narrower but on desktop widths it didn't seem appropriate.  
- Center aligned `<h1>` and `<h2>`'s (main text is still left justified).
- Decreased font-size of h2s a tad on widths less than 640px.
- Increased `<p>` (main text) font-size on widths less than 440px for mobile-friendly readability.

These are 1080, 1080, 768, 640, and 440 from left to right. 
![tiy-thank-you-ui-01](https://user-images.githubusercontent.com/20695956/30778587-4e2c32e0-a0a7-11e7-8f56-2058d74bfd7b.jpg)
